### PR TITLE
fix: substituindo o link quebrado por outro link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Engenharia reversa é um campo vasto e complexo. Isso aqui pretende ser um compi
 ## 0. Para os que não tem base nenhuma de linguagem C, recomendo (pode ser uma lida superficial):
 - http://www.facom.ufu.br/~gustavo/ED1/Apostila_Linguagem_C.pdf
 
-- http://www.ufjf.br/petcivil/files/2009/02/Apostila-de-Introdu%C3%A7%C3%A3o-%C3%A0-Linguagem-C.pdf (um pouco mais curto)
+- https://www.programiz.com/c-programming (Mais curto e com interface amigável)
 
 ## 1. Base da base de assembly e GDB:
  #### - Sistemas numericos: 


### PR DESCRIPTION
O link: https://www.ufjf.br/petcivil/files/2009/02/Apostila-de-Introdu%c3%a7%c3%a3o-%c3%a0-Linguagem-C.pdf está quebrado, retorna 404. Substitui com um site em inglês com uma interface legal de aprender dividida por módulos. É um resumão introdutório de C.

Obs: valeu por compartilhar este conteúdo está ajudando demais!